### PR TITLE
#46 style with 4 spaces indentation instead of 2

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,0 +1,55 @@
+on:
+  issue_comment:
+    types: [created]
+name: Commands
+jobs:
+  document:
+    if: startsWith(github.event.comment.body, '/document')
+    name: document
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install dependencies
+        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
+      - name: Document
+        run: Rscript -e 'roxygen2::roxygenise()'
+      - name: commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add man/\* NAMESPACE
+          git commit -m 'Document'
+      - uses: r-lib/actions/pr-push@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  style:
+    if: startsWith(github.event.comment.body, '/style')
+    name: style
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install dependencies
+        run: Rscript -e 'install.packages("styler")'
+      - name: Style
+        run: Rscript -e 'styler::style_pkg()'
+      - name: commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add \*.R
+          git commit -m 'Style'
+      - uses: r-lib/actions/pr-push@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/R/kobo-client.R
+++ b/R/kobo-client.R
@@ -6,60 +6,60 @@
 #' @importFrom usethis ui_stop
 #' @export
 KoboClient <- R6::R6Class("KoboClient",
-  inherit = crul::HttpClient,
-  private = list(
-    base_url = "",
-    kobo_token = ""
-  ),
-  public = list(
-    #' @description
-    #' Initialization method for class "KoboClient".
-    #' @param base_url character. The full base URL of the API.
-    #' @param kobo_token character. The API token. Defaults to requesting
-    #'  the system environment variable `KBTBR_TOKEN`.
-    initialize = function(base_url,
-                          kobo_token = Sys.getenv("KBTBR_TOKEN")) {
+    inherit = crul::HttpClient,
+    private = list(
+        base_url = "",
+        kobo_token = ""
+    ),
+    public = list(
+        #' @description
+        #' Initialization method for class "KoboClient".
+        #' @param base_url character. The full base URL of the API.
+        #' @param kobo_token character. The API token. Defaults to requesting
+        #'  the system environment variable `KBTBR_TOKEN`.
+        initialize = function(base_url,
+                              kobo_token = Sys.getenv("KBTBR_TOKEN")) {
 
-      # Check and set private fields
-      checkmate::assert_character(kobo_token)
-      if (kobo_token == "") {
-        usethis::ui_stop(
-          "No valid token detected. Set the KBTBR_TOKEN environment
+            # Check and set private fields
+            checkmate::assert_character(kobo_token)
+            if (kobo_token == "") {
+                usethis::ui_stop(
+                    "No valid token detected. Set the KBTBR_TOKEN environment
                     variable or pass the token directly to the function
                     (not recommended)."
-        )
-      }
-      private$kobo_token <- kobo_token
-      private$base_url <- base_url
+                )
+            }
+            private$kobo_token <- kobo_token
+            private$base_url <- base_url
 
-      super$initialize(
-        url = base_url,
-        headers = list(
-          Authorization = paste0("Token ", kobo_token)
-        )
-      )
-    },
-    #' @description
-    #' Perform a GET request (with additional checks)
-    #'
-    #' @details
-    #' Extension of the `crul::HttpClient$get()` method that checks
-    #' the HttpResponse object on status, that it is of type
-    #' `application/json`, and parses the response text subsequently from
-    #' JSON to R list representation.
-    #' @param path character. Path component of the endpoint.
-    #' @param query list. A named list which is parsed to the query
-    #'  component. The order is not hierarchical.
-    #' @param ... crul-options. Additional option arguments, see
-    #'  [`crul::HttpClient`] for reference
-    #' @return Returns a list, parsed from the HttpResponse JSON object.
-    get = function(path, query = list(), ...) {
-      res <- super$get(path = path, query = query, ...)
-      # Perform additional checks, json to list parsing
-      res$raise_for_status()
-      res$raise_for_ct_json()
-      res$parse("UTF-8") %>%
-        jsonlite::fromJSON()
-    }
-  )
+            super$initialize(
+                url = base_url,
+                headers = list(
+                    Authorization = paste0("Token ", kobo_token)
+                )
+            )
+        },
+        #' @description
+        #' Perform a GET request (with additional checks)
+        #'
+        #' @details
+        #' Extension of the `crul::HttpClient$get()` method that checks
+        #' the HttpResponse object on status, that it is of type
+        #' `application/json`, and parses the response text subsequently from
+        #' JSON to R list representation.
+        #' @param path character. Path component of the endpoint.
+        #' @param query list. A named list which is parsed to the query
+        #'  component. The order is not hierarchical.
+        #' @param ... crul-options. Additional option arguments, see
+        #'  [`crul::HttpClient`] for reference
+        #' @return Returns a list, parsed from the HttpResponse JSON object.
+        get = function(path, query = list(), ...) {
+            res <- super$get(path = path, query = query, ...)
+            # Perform additional checks, json to list parsing
+            res$raise_for_status()
+            res$raise_for_ct_json()
+            res$parse("UTF-8") %>%
+                jsonlite::fromJSON()
+        }
+    )
 )

--- a/R/kobo.R
+++ b/R/kobo.R
@@ -6,78 +6,78 @@
 #' interactions with the various endpoints.
 #' @export
 Kobo <- R6::R6Class("Kobo",
-  private = list(
-    session_v2 = NULL,
-    session_v1 = NULL
-  ),
-  public = list(
-    #' @description
-    #' Initialization method for class "Kobo".
-    #' @param base_url_v2 character. The base URL of the API version 2
-    #'  (known as /api/v2). For example: https://kobo.correlaid.org.
-    #' @param base_url_v1 character. The base URL of the API of your KoBoCAT
-    #'  API (also known as /api/v1). Defaults to NULL.
-    #'  For example: https://kc.correlaid.org.
-    #' @param kobo_token character. The API token. Defaults to requesting
-    #'  the systen environment `KBTBR_TOKEN`.
-    #' @param session_v2 KoboClient. Alternatively, pass directly
-    #' a KoboClient instance for the API version v2.
-    #' @param session_v1 KoboKlient. In addition to session_v2 one can pass
-    #' also a KoboClient instance for the API version v1.
-    initialize = function(base_url_v2 = NULL, base_url_v1 = NULL,
-                          kobo_token = Sys.getenv("KBTBR_TOKEN"),
-                          session_v2 = NULL, session_v1 = NULL) {
+    private = list(
+        session_v2 = NULL,
+        session_v1 = NULL
+    ),
+    public = list(
+        #' @description
+        #' Initialization method for class "Kobo".
+        #' @param base_url_v2 character. The base URL of the API version 2
+        #'  (known as /api/v2). For example: https://kobo.correlaid.org.
+        #' @param base_url_v1 character. The base URL of the API of your KoBoCAT
+        #'  API (also known as /api/v1). Defaults to NULL.
+        #'  For example: https://kc.correlaid.org.
+        #' @param kobo_token character. The API token. Defaults to requesting
+        #'  the systen environment `KBTBR_TOKEN`.
+        #' @param session_v2 KoboClient. Alternatively, pass directly
+        #' a KoboClient instance for the API version v2.
+        #' @param session_v1 KoboKlient. In addition to session_v2 one can pass
+        #' also a KoboClient instance for the API version v1.
+        initialize = function(base_url_v2 = NULL, base_url_v1 = NULL,
+                              kobo_token = Sys.getenv("KBTBR_TOKEN"),
+                              session_v2 = NULL, session_v1 = NULL) {
 
-      # one has to pass at least base_url_v2 or session_v2
-      if (!xor(
-        checkmate::test_null(base_url_v2),
-        checkmate::test_null(session_v2)
-      )) {
-        stop("Either base_url_v2 or session_v2 must be provided")
-      }
+            # one has to pass at least base_url_v2 or session_v2
+            if (!xor(
+                checkmate::test_null(base_url_v2),
+                checkmate::test_null(session_v2)
+            )) {
+                stop("Either base_url_v2 or session_v2 must be provided")
+            }
 
-      if (!checkmate::test_null(base_url_v2)) {
-        private$session_v2 <- KoboClient$new(base_url_v2, kobo_token)
-      } else {
-        private$session_v2 <- session_v2
-      }
+            if (!checkmate::test_null(base_url_v2)) {
+                private$session_v2 <- KoboClient$new(base_url_v2, kobo_token)
+            } else {
+                private$session_v2 <- session_v2
+            }
 
-      if (!checkmate::test_null(base_url_v1)) {
-        private$session_v1 <- KoboClient$new(base_url_v1, kobo_token)
-      } else if (!checkmate::test_null(session_v1)) {
-        private$session_v1 <- session_v1
-      } else {
-        # TODO: add to warning once we know what functnality is covered by v1.
-        usethis::ui_info("You have not passed base_url_v1. This means you cannot use the following functions:")
-      }
-    },
-    #' @description
-    #' Wrapper for the GET method of internal session objects.
-    #' @param path character. Path component of the endpoint.
-    #' @param query list. A named list which is parsed to the query
-    #'  component. The order is not hierarchical.
-    #' @param version character. Indicates on which API version the request
-    #'  should be executed (available: `v1`, `v2`). Defaults to `v2`.
-    get = function(path, query = list(format = "json"), version = "v2") {
-      if (version == "v2") {
-        private$session_v2$get(path = paste0("api/v2/", path), query = query)
-      } else if (version == "v1") {
-        if (checkmate::test_null(private$session_v1)) {
-          usethis::ui_stop("Session for API v1 is not initalized. Please re-initalize the Kobo client with the base_url_v1 argument.")
-        }
-        private$session_v1$get(path = paste0("api/v1/", path), query = query)
-      } else {
-        usethis::ui_stop(
-          "Invalid version. Must be either v1 or v2.
+            if (!checkmate::test_null(base_url_v1)) {
+                private$session_v1 <- KoboClient$new(base_url_v1, kobo_token)
+            } else if (!checkmate::test_null(session_v1)) {
+                private$session_v1 <- session_v1
+            } else {
+                # TODO: add to warning once we know what functnality is covered by v1.
+                usethis::ui_info("You have not passed base_url_v1. This means you cannot use the following functions:")
+            }
+        },
+        #' @description
+        #' Wrapper for the GET method of internal session objects.
+        #' @param path character. Path component of the endpoint.
+        #' @param query list. A named list which is parsed to the query
+        #'  component. The order is not hierarchical.
+        #' @param version character. Indicates on which API version the request
+        #'  should be executed (available: `v1`, `v2`). Defaults to `v2`.
+        get = function(path, query = list(format = "json"), version = "v2") {
+            if (version == "v2") {
+                private$session_v2$get(path = paste0("api/v2/", path), query = query)
+            } else if (version == "v1") {
+                if (checkmate::test_null(private$session_v1)) {
+                    usethis::ui_stop("Session for API v1 is not initalized. Please re-initalize the Kobo client with the base_url_v1 argument.")
+                }
+                private$session_v1$get(path = paste0("api/v1/", path), query = query)
+            } else {
+                usethis::ui_stop(
+                    "Invalid version. Must be either v1 or v2.
                     Come back in a couple of years."
-        )
-      }
-    },
-    #' @description
-    #' Example method to send a GET request to the `assets` endpoint
-    #' (due to default to `v2`, no further specification is needed).
-    get_assets = function() {
-      self$get("assets/")
-    }
-  )
+                )
+            }
+        },
+        #' @description
+        #' Example method to send a GET request to the `assets` endpoint
+        #' (due to default to `v2`, no further specification is needed).
+        get_assets = function() {
+            self$get("assets/")
+        }
+    )
 )

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ To install the package dependencies:
 install.packages("renv")
 renv::install()
 ```
+
+## Code styling
+Please style any code with the following [styler](https://styler.r-lib.org/) command:
+
+```r
+styler::style_pkg(style = styler::tidyverse_style, indent_by = 4) 
+```
 ## Package development workflow
 
 ## Branching model

--- a/tests/testthat/setup-kbtbr.R
+++ b/tests/testthat/setup-kbtbr.R
@@ -3,19 +3,19 @@ library("vcr") # *Required* as vcr is set up on loading
 vcr_dir <- vcr::vcr_test_path("fixtures")
 
 if (!nzchar(Sys.getenv("KBTBR_TOKEN"))) {
-  if (dir.exists(vcr_dir)) {
-    # Fake API token to fool our package
-    Sys.setenv("KBTBR_TOKEN" = "fakebearertoken")
-  } else {
-    # If there's no mock files nor API token, impossible to run tests
-    stop("No API key nor cassettes, tests cannot be run.",
-      call. = FALSE
-    )
-  }
+    if (dir.exists(vcr_dir)) {
+        # Fake API token to fool our package
+        Sys.setenv("KBTBR_TOKEN" = "fakebearertoken")
+    } else {
+        # If there's no mock files nor API token, impossible to run tests
+        stop("No API key nor cassettes, tests cannot be run.",
+            call. = FALSE
+        )
+    }
 }
 
 invisible(vcr::vcr_configure(
-  dir = vcr_dir,
-  filter_request_headers = list(Authorization = "fakebearertoken")
+    dir = vcr_dir,
+    filter_request_headers = list(Authorization = "fakebearertoken")
 ))
 vcr::check_cassette_names()

--- a/tests/testthat/test-kobo-client.R
+++ b/tests/testthat/test-kobo-client.R
@@ -3,33 +3,33 @@ BASE_URL <- "https://kobo.correlaid.org"
 #' Testing $get_* methods
 
 vcr::use_cassette("kobo-client-403", {
-  test_that("Requests with faulty token throw error", {
-    # Case: Faulty token is via envvar, get request fails
-    withr::with_envvar(
-      new = c("KBTBR_TOKEN" = "foo"),
-      code = {
-        kc <- KoboClient$new(base_url = BASE_URL)
-        expect_error(kc$get("api/v2/assets/"), regexp = "403")
-      }
-    )
-  })
+    test_that("Requests with faulty token throw error", {
+        # Case: Faulty token is via envvar, get request fails
+        withr::with_envvar(
+            new = c("KBTBR_TOKEN" = "foo"),
+            code = {
+                kc <- KoboClient$new(base_url = BASE_URL)
+                expect_error(kc$get("api/v2/assets/"), regexp = "403")
+            }
+        )
+    })
 })
 
 test_that("Kobo Client can fetch assets", {
-  vcr::use_cassette("kobo-client-get-assets-simple-get", {
-    koboclient <- KoboClient$new(base_url = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
-    assets <- koboclient$get("api/v2/assets/", query = list(format = "json")) # trailing slash again!
-  })
-  expect_setequal(names(assets), c("count", "next", "previous", "results"))
-  expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
-  expect_equal(nrow(assets$results), 8)
-  expect_equal(assets$count, 8)
+    vcr::use_cassette("kobo-client-get-assets-simple-get", {
+        koboclient <- KoboClient$new(base_url = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
+        assets <- koboclient$get("api/v2/assets/", query = list(format = "json")) # trailing slash again!
+    })
+    expect_setequal(names(assets), c("count", "next", "previous", "results"))
+    expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
+    expect_equal(nrow(assets$results), 8)
+    expect_equal(assets$count, 8)
 })
 
 
 vcr::use_cassette("kobo-client-get-404", {
-  test_that("non existing route throws 404 error", {
-    koboclient <- KoboClient$new(base_url = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
-    expect_error(koboclient$get("api/v2/doesnotexist/"), regexp = "404")
-  })
+    test_that("non existing route throws 404 error", {
+        koboclient <- KoboClient$new(base_url = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
+        expect_error(koboclient$get("api/v2/doesnotexist/"), regexp = "404")
+    })
 })

--- a/tests/testthat/test-kobo.R
+++ b/tests/testthat/test-kobo.R
@@ -3,100 +3,100 @@ BASE_URL <- "https://kobo.correlaid.org"
 #' Testing basic properties, construction
 
 test_that("the error from KoboClient is propagated correctly if we fail to provide a token", {
-  withr::with_envvar(
-    new = c("KBTBR_TOKEN" = ""),
-    code = {
-      expect_error(
-        object = Kobo$new(base_url_v2 = BASE_URL),
-        regexp = "No valid token detected."
-      )
-    }
-  )
+    withr::with_envvar(
+        new = c("KBTBR_TOKEN" = ""),
+        code = {
+            expect_error(
+                object = Kobo$new(base_url_v2 = BASE_URL),
+                regexp = "No valid token detected."
+            )
+        }
+    )
 })
 
 test_that("Kobo is initialized correctly if we provide a kobo_token manually with empty envvar.", {
-  withr::with_envvar(
-    new = c("KBTBR_TOKEN" = ""),
-    code = {
-      kobo_obj <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = "foo")
-      expect_identical(
-        class(kobo_obj),
-        c("Kobo", "R6")
-      )
-    }
-  )
+    withr::with_envvar(
+        new = c("KBTBR_TOKEN" = ""),
+        code = {
+            kobo_obj <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = "foo")
+            expect_identical(
+                class(kobo_obj),
+                c("Kobo", "R6")
+            )
+        }
+    )
 })
 
 
 test_that("Kobo is initialized correctly if we provide a KoboClient instance", {
-  withr::with_envvar(
-    new = c("KBTBR_TOKEN" = ""),
-    code = {
-      koboclient_instance <- KoboClient$new(BASE_URL, kobo_token = "foo")
-      kobo_obj <- Kobo$new(session_v2 = koboclient_instance)
-      expect_identical(
-        class(kobo_obj),
-        c("Kobo", "R6")
-      )
-    }
-  )
+    withr::with_envvar(
+        new = c("KBTBR_TOKEN" = ""),
+        code = {
+            koboclient_instance <- KoboClient$new(BASE_URL, kobo_token = "foo")
+            kobo_obj <- Kobo$new(session_v2 = koboclient_instance)
+            expect_identical(
+                class(kobo_obj),
+                c("Kobo", "R6")
+            )
+        }
+    )
 })
 
 test_that("we get a message if we do not specify base_url_v1, but Kobo is initialized.", {
-  expect_message(
-    {
-      kobo_obj <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = "foo")
-    },
-    regexp = "You have not passed base_url_v1. This means you cannot use"
-  )
-  expect_identical(
-    class(kobo_obj),
-    c("Kobo", "R6")
-  )
+    expect_message(
+        {
+            kobo_obj <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = "foo")
+        },
+        regexp = "You have not passed base_url_v1. This means you cannot use"
+    )
+    expect_identical(
+        class(kobo_obj),
+        c("Kobo", "R6")
+    )
 })
 #' -----------------------------------------------------------------------------
 #' Testing $get_* methods
 test_that("Request to v1 throws error if v1 session is not initialized", {
-  kobo <- Kobo$new(base_url_v2 = BASE_URL)
-  expect_error(kobo$get("submissions/", version = "v1"),
-    regexp = "Session for API v1 is not initalized"
-  )
+    kobo <- Kobo$new(base_url_v2 = BASE_URL)
+    expect_error(kobo$get("submissions/", version = "v1"),
+        regexp = "Session for API v1 is not initalized"
+    )
 })
 
 test_that("Kobo can fetch assets", {
-  # the use_cassette command looks into the fixtures directory and checks
-  # whether a "cassette" with the given name already exists. if yes, it loads it. if no, the
-  # code is run and the response is saved as a cassette.
-  vcr::use_cassette("kobo-get-assets", {
-    kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
-    assets <- kobo$get_assets()
-  })
-  expect_setequal(names(assets), c("count", "next", "previous", "results"))
-  expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
-  expect_equal(nrow(assets$results), 8)
-  expect_equal(assets$count, 8)
+    # the use_cassette command looks into the fixtures directory and checks
+    # whether a "cassette" with the given name already exists. if yes, it loads it. if no, the
+    # code is run and the response is saved as a cassette.
+    vcr::use_cassette("kobo-get-assets", {
+        kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
+        assets <- kobo$get_assets()
+    })
+    expect_setequal(names(assets), c("count", "next", "previous", "results"))
+    expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
+    expect_equal(nrow(assets$results), 8)
+    expect_equal(assets$count, 8)
 })
 
 test_that("Kobo can fetch assets using simple get", {
-  vcr::use_cassette("kobo-get-assets-simple-get", {
-    kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
-    assets <- kobo$get("assets/") # trailing slash again!
-  })
-  expect_setequal(names(assets), c("count", "next", "previous", "results"))
-  expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
-  expect_equal(nrow(assets$results), 8)
-  expect_equal(assets$count, 8)
+    vcr::use_cassette("kobo-get-assets-simple-get", {
+        kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
+        assets <- kobo$get("assets/") # trailing slash again!
+    })
+    expect_setequal(names(assets), c("count", "next", "previous", "results"))
+    expect_true(all(c("url", "owner", "kind", "name", "asset_type") %in% colnames(assets$results)))
+    expect_equal(nrow(assets$results), 8)
+    expect_equal(assets$count, 8)
 })
 
 
 vcr::use_cassette("kobo-get-404", {
-  test_that("non existing route throws 404 error", {
-    kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
-    expect_error(kobo$get("doesnotexist/"), regexp = "404")
-  })
+    test_that("non existing route throws 404 error", {
+        kobo <- Kobo$new(base_url_v2 = BASE_URL, kobo_token = Sys.getenv("KBTBR_TOKEN"))
+        expect_error(kobo$get("doesnotexist/"), regexp = "404")
+    })
 })
 
 test_that("non-existing kobo host throws error", {
-  kobo <- Kobo$new(base_url_v2 = "https://nokobohere.correlaid.org", kobo_token = Sys.getenv("KBTBR_TOKEN"))
-  expect_error(kobo$get("assets/"), regexp = "^SSL.+certificate.+")
+    kobo <- Kobo$new(base_url_v2 = "https://nokobohere.correlaid.org", kobo_token = Sys.getenv("KBTBR_TOKEN"))
+    expect_error(kobo$get("assets/"), regexp = "^SSL.+certificate.+")
 })


### PR DESCRIPTION
closes #46 

- restyles all files with four spaces indentation instead of 2
- add instruction to README
- add PR command (see [here](https://usethis.r-lib.org/reference/use_github_action.html#use-github-action-pr-commands))